### PR TITLE
[docker] Add bash to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ FROM ${RUNNER_IMAGE}
 
 COPY --from=build-env /go/src/github.com/sagaxyz/sagacli/build/sscd /usr/bin/sscd
 
-RUN apk add gcompat
+RUN apk add gcompat bash
 
 EXPOSE 26656
 EXPOSE 26660


### PR DESCRIPTION
It's 1MB and we need it for the screenshot since sh doesn't support arrays easily.