### PR TITLE
bugfix(x/chainlet): process all chainlets during auto-upgrade

### DIFF
--- a/x/chainlet/keeper/chainlet.go
+++ b/x/chainlet/keeper/chainlet.go
@@ -219,9 +219,9 @@ func (k *Keeper) AutoUpgradeChainlets(ctx sdk.Context) error {
 			iter.Close()
 			return err
 		}
-		if latestVersion == chainlet.ChainletStackVersion {
-			iter.Close()
-			return nil
+		if chainlet.ChainletStackVersion == latestVersion {
+			ctx.Logger().Debug(fmt.Sprintf("chainlet %s: %s is at its latest available version\n", chainlet.ChainId, chainlet.ChainletStackVersion))
+			continue
 		}
 
 		available, err := k.chainletStackVersionAvailable(ctx, chainlet.ChainletStackName, latestVersion)
@@ -229,11 +229,6 @@ func (k *Keeper) AutoUpgradeChainlets(ctx sdk.Context) error {
 			iter.Close()
 			//TODO change to panic in the future, should never happen if the loaded versions are consistent with the state
 			return fmt.Errorf("chainlet stack %s has unavailable version %s loaded", chainlet.ChainletStackName, latestVersion)
-		}
-
-		if chainlet.ChainletStackVersion == latestVersion {
-			ctx.Logger().Debug(fmt.Sprintf("chainlet %s: %s is at its latest available version\n", chainlet.ChainId, chainlet.ChainletStackVersion))
-			continue
 		}
 
 		ctx.Logger().Info(fmt.Sprintf("upgrading chainlet %s: %s to %s\n", chainlet.ChainId, chainlet.ChainletStackVersion, latestVersion))


### PR DESCRIPTION
Previously, the AutoUpgradeChainlets method would exit early when the first chainlet was already at the latest version, leaving subsequent chainlets unprocessed. This commit replaces the early return with a continue statement, ensuring that all chainlets are checked and upgraded if necessary.

Closes #33