### PR TITLE
GMP handler update

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,7 @@ on:
     branches:
       - "**"
 jobs:
-  build-and-deploy:
+  build-and-test:
     runs-on: ubuntu-latest
     env:
       GOPRIVATE: github.com/sagaxyz/*

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,26 @@
+name: Compile And Test
+on:
+  push:
+    branches:
+      - "**"
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    env:
+      GOPRIVATE: github.com/sagaxyz/*
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "./go.mod"
+          cache: true
+      - run: go version
+
+      - name: Compile
+        run: make build
+
+      - name: Test
+        run: go test ./...

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -1,0 +1,30 @@
+name: golangci-lint
+on:
+  push:
+    branches:
+      - '**'
+permissions:
+  contents: read
+  # Optional: allow read access to pull requests. Use with `only-new-issues` option.
+  # pull-requests: read
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    env:
+      GOPRIVATE: github.com/sagaxyz/*
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "./go.mod"
+          cache: true
+      - run: go version
+      
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          args: --timeout 600s

--- a/.github/workflows/gosec.yaml
+++ b/.github/workflows/gosec.yaml
@@ -1,0 +1,45 @@
+name: Run Gosec
+on:
+  pull_request:
+    branches:
+      - main
+      - release/**
+    paths:
+      - "**/*.go"
+      - "go.mod"
+      - "go.sum"
+  push:
+    branches:
+      - main
+    paths:
+      - "**/*.go"
+      - "go.mod"
+      - "go.sum"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  Gosec:
+    permissions:
+      security-events: write
+
+    runs-on: ubuntu-latest
+    env:
+      GO111MODULE: on
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@v4
+
+      - name: Run Gosec Security Scanner
+        uses: securego/gosec@master
+        with:
+          # we let the report trigger content trigger a failure using the GitHub Security features.
+          args: "-exclude=G101,G107 -exclude-dir=systemtests -exclude-generated -no-fail -fmt sarif -out results.sarif ./..."
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          # Path to SARIF file relative to the root of the repository
+          sarif_file: results.sarif

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
         

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -14,5 +14,3 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@master
-        env:
-          SHELLCHECK_OPTS: -e SC2086

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -1,0 +1,18 @@
+name: ShellCheck
+
+on: [push]
+
+permissions:
+ contents: read
+jobs:
+  shellcheck:
+    name: Run shellcheck
+    runs-on: ubuntu-latest
+    env:
+      GOPRIVATE: github.com/sagaxyz/*
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master
+        env:
+          SHELLCHECK_OPTS: -e SC2086

--- a/app/app.go
+++ b/app/app.go
@@ -601,6 +601,8 @@ func New(
 	)
 
 	govRouter := govv1beta1.NewRouter()
+	//nolint:staticcheck
+	//already fixed in main
 	govRouter.
 		AddRoute(govtypes.RouterKey, govv1beta1.ProposalHandler).
 		AddRoute(paramproposal.RouterKey, params.NewParamChangeProposalHandler(app.ParamsKeeper)).

--- a/app/app.go
+++ b/app/app.go
@@ -138,6 +138,7 @@ import (
 	gmpmoduletypes "github.com/sagaxyz/ssc/x/gmp/types"
 
 	upgrade02 "github.com/sagaxyz/ssc/app/upgrades/0.2"
+	upgrade03 "github.com/sagaxyz/ssc/app/upgrades/0.3"
 
 	// this line is used by starport scaffolding # stargate/app/moduleImport
 
@@ -1100,6 +1101,7 @@ func (app *App) ModuleManager() *module.Manager {
 func (app *App) RegisterUpgradeHandlers() {
 	baseAppLegacySS := app.ParamsKeeper.Subspace(baseapp.Paramspace).WithKeyTable(paramstypes.ConsensusParamsKeyTable())
 	app.UpgradeKeeper.SetUpgradeHandler(upgrade02.Name, upgrade02.UpgradeHandler(app.mm, app.configurator, app.ParamsKeeper, &app.ConsensusParamsKeeper, app.IBCKeeper.ClientKeeper, baseAppLegacySS))
+	app.UpgradeKeeper.SetUpgradeHandler(upgrade03.Name, upgrade03.UpgradeHandler(app.mm, app.configurator))
 
 	upgradeInfo, err := app.UpgradeKeeper.ReadUpgradeInfoFromDisk()
 	if err != nil {

--- a/app/simulation_test.go
+++ b/app/simulation_test.go
@@ -309,12 +309,10 @@ func TestAppImportExport(t *testing.T) {
 
 	ctxA := bApp.NewContextLegacy(true, tmproto.Header{Height: bApp.LastBlockHeight()})
 	ctxB := newApp.NewContextLegacy(true, tmproto.Header{Height: bApp.LastBlockHeight()})
-	if _, err = newApp.ModuleManager().InitGenesis(ctxB, bApp.AppCodec(), genesisState); err != nil {
-		panic(err)
-	}
-	if err = newApp.StoreConsensusParams(ctxB, exported.ConsensusParams); err != nil {
-		panic(err)
-	}
+	_, err = newApp.ModuleManager().InitGenesis(ctxB, bApp.AppCodec(), genesisState)
+	require.NoError(t, err)
+	err = newApp.StoreConsensusParams(ctxB, exported.ConsensusParams)
+	require.NoError(t, err)
 
 	fmt.Printf("comparing stores...\n")
 

--- a/app/upgrades/0.3/upgrades.go
+++ b/app/upgrades/0.3/upgrades.go
@@ -1,0 +1,16 @@
+package v03
+
+import (
+	"context"
+
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+)
+
+const Name = "0.2-to-0.3"
+
+func UpgradeHandler(mm *module.Manager, configurator module.Configurator) upgradetypes.UpgradeHandler {
+	return func(ctx context.Context, _ upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
+		return mm.RunMigrations(ctx, configurator, vm)
+	}
+}

--- a/cmd/sscd/cmd/root.go
+++ b/cmd/sscd/cmd/root.go
@@ -225,7 +225,10 @@ func overwriteFlagDefaults(c *cobra.Command, defaults map[string]string) {
 	set := func(s *pflag.FlagSet, key, val string) {
 		if f := s.Lookup(key); f != nil {
 			f.DefValue = val
-			f.Value.Set(val)
+			err := f.Value.Set(val)
+			if err != nil {
+				panic(err)
+			}
 		}
 	}
 	for key, val := range defaults {

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -29,6 +29,7 @@ func handler(title string) http.HandlerFunc {
 	t, _ := httptemplate.ParseFS(template, indexFile)
 
 	return func(w http.ResponseWriter, req *http.Request) {
+		//nolint:errcheck
 		t.Execute(w, struct {
 			Title string
 			URL   string

--- a/x/gmp/client/cli/tx.go
+++ b/x/gmp/client/cli/tx.go
@@ -14,11 +14,6 @@ var (
 	DefaultRelativePacketTimeoutTimestamp = (time.Duration(10) * time.Minute).Nanoseconds()
 )
 
-const (
-	flagPacketTimeoutTimestamp = "packet-timeout-timestamp"
-	listSeparator              = ","
-)
-
 // GetTxCmd returns the transaction commands for this module
 func GetTxCmd() *cobra.Command {
 	cmd := &cobra.Command{

--- a/x/gmp/keeper/msg_server_test.go
+++ b/x/gmp/keeper/msg_server_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	keepertest "github.com/sagaxyz/ssc/testutil/keeper"
 	"github.com/sagaxyz/ssc/x/gmp/keeper"
 	"github.com/sagaxyz/ssc/x/gmp/types"
@@ -13,7 +12,7 @@ import (
 
 func setupMsgServer(t testing.TB) (types.MsgServer, context.Context) {
 	k, ctx := keepertest.GmpKeeper(t)
-	return keeper.NewMsgServerImpl(*k), sdk.WrapSDKContext(ctx)
+	return keeper.NewMsgServerImpl(*k), ctx
 }
 
 func TestMsgServer(t *testing.T) {

--- a/x/gmp/keeper/query_params_test.go
+++ b/x/gmp/keeper/query_params_test.go
@@ -3,7 +3,6 @@ package keeper_test
 import (
 	"testing"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	testkeeper "github.com/sagaxyz/ssc/testutil/keeper"
 	"github.com/sagaxyz/ssc/x/gmp/types"
 	"github.com/stretchr/testify/require"
@@ -11,11 +10,10 @@ import (
 
 func TestParamsQuery(t *testing.T) {
 	keeper, ctx := testkeeper.GmpKeeper(t)
-	wctx := sdk.WrapSDKContext(ctx)
 	params := types.DefaultParams()
 	keeper.SetParams(ctx, params)
 
-	response, err := keeper.Params(wctx, &types.QueryParamsRequest{})
+	response, err := keeper.Params(ctx, &types.QueryParamsRequest{})
 	require.NoError(t, err)
 	require.Equal(t, &types.QueryParamsResponse{Params: params}, response)
 }

--- a/x/gmp/module.go
+++ b/x/gmp/module.go
@@ -73,7 +73,7 @@ func (AppModuleBasic) ValidateGenesis(cdc codec.JSONCodec, config client.TxEncod
 
 // RegisterGRPCGatewayRoutes registers the gRPC Gateway routes for the module
 func (AppModuleBasic) RegisterGRPCGatewayRoutes(clientCtx client.Context, mux *runtime.ServeMux) {
-	types.RegisterQueryHandlerClient(context.Background(), mux, types.NewQueryClient(clientCtx))
+	types.RegisterQueryHandlerClient(context.Background(), mux, types.NewQueryClient(clientCtx)) //nolint:errcheck
 }
 
 // GetTxCmd returns the root Tx command for the module. The subcommands of this root command are used by end-users to generate new transactions containing messages defined in the module

--- a/x/gmp/module_ibc.go
+++ b/x/gmp/module_ibc.go
@@ -167,11 +167,13 @@ func (im IBCModule) OnRecvPacket(
 		data.Memo = string(pfmPayload)
 		modulePacket.Data, err = types.ModuleCdc.MarshalJSON(&data)
 		if err != nil {
+			ctx.Logger().Info(fmt.Sprintf("failed to marshal updated data: %s", err.Error()))
 			return channeltypes.NewErrorAcknowledgement(cosmossdkerrors.Wrapf(transfertypes.ErrInvalidMemo, "cannot marshal updated data: %s", err.Error()))
 		}
 		return im.app.OnRecvPacket(ctx, modulePacket, relayer)
 
 	default:
+		ctx.Logger().Info(fmt.Sprintf("unrecognized message type: %v", msg))
 		return channeltypes.NewErrorAcknowledgement(cosmossdkerrors.Wrapf(transfertypes.ErrInvalidMemo, "unrecognized message type (%d)", msg.Type))
 	}
 }

--- a/x/gmp/module_ibc.go
+++ b/x/gmp/module_ibc.go
@@ -139,7 +139,7 @@ func (im IBCModule) OnRecvPacket(
 		return im.app.OnRecvPacket(ctx, modulePacket, relayer)
 	}
 
-	if msg.Payload == nil {
+	if len(msg.Payload) == 0 {
 		return im.app.OnRecvPacket(ctx, modulePacket, relayer)
 	}
 

--- a/x/gmp/module_ibc.go
+++ b/x/gmp/module_ibc.go
@@ -164,7 +164,7 @@ func (im IBCModule) OnRecvPacket(
 			return im.app.OnRecvPacket(ctx, modulePacket, relayer)
 		}
 		pfmPayload := args[0].(string)
-		data.Memo = string(pfmPayload)
+		data.Memo = pfmPayload
 		modulePacket.Data, err = types.ModuleCdc.MarshalJSON(&data)
 		if err != nil {
 			ctx.Logger().Error(fmt.Sprintf("failed to marshal updated data: %s", err.Error()))

--- a/x/gmp/module_ibc.go
+++ b/x/gmp/module_ibc.go
@@ -160,7 +160,7 @@ func (im IBCModule) OnRecvPacket(
 		args, err := abi.Arguments{{Type: payloadType}}.Unpack(payloadData)
 		if err != nil {
 			ctx.Logger().Debug(fmt.Sprintf("failed to unpack: %s", err.Error()))
-			return channeltypes.NewErrorAcknowledgement(cosmossdkerrors.Wrapf(transfertypes.ErrInvalidMemo, "unable to unpack payload (%s)", err.Error()))
+			return im.app.OnRecvPacket(ctx, modulePacket, relayer)
 		}
 		pfmPayload := args[0].(string)
 		data.Memo = string(pfmPayload)

--- a/x/gmp/module_ibc.go
+++ b/x/gmp/module_ibc.go
@@ -151,7 +151,7 @@ func (im IBCModule) OnRecvPacket(
 		ctx.Logger().Debug(fmt.Sprintf("Got general message with token: %v", msg))
 		payloadType, err := abi.NewType("string", "", nil)
 		if err != nil {
-			ctx.Logger().Info(fmt.Sprintf("failed to create reflection: %s", err.Error()))
+			ctx.Logger().Error(fmt.Sprintf("failed to create reflection: %s", err.Error()))
 			return channeltypes.NewErrorAcknowledgement(cosmossdkerrors.Wrapf(transfertypes.ErrInvalidMemo, "unable to define new abi type (%s)", err.Error()))
 		}
 		payloadData := msg.Payload
@@ -167,7 +167,7 @@ func (im IBCModule) OnRecvPacket(
 		data.Memo = string(pfmPayload)
 		modulePacket.Data, err = types.ModuleCdc.MarshalJSON(&data)
 		if err != nil {
-			ctx.Logger().Info(fmt.Sprintf("failed to marshal updated data: %s", err.Error()))
+			ctx.Logger().Error(fmt.Sprintf("failed to marshal updated data: %s", err.Error()))
 			return channeltypes.NewErrorAcknowledgement(cosmossdkerrors.Wrapf(transfertypes.ErrInvalidMemo, "cannot marshal updated data: %s", err.Error()))
 		}
 		return im.app.OnRecvPacket(ctx, modulePacket, relayer)

--- a/x/gmp/module_ibc.go
+++ b/x/gmp/module_ibc.go
@@ -159,6 +159,7 @@ func (im IBCModule) OnRecvPacket(
 
 		args, err := abi.Arguments{{Type: payloadType}}.Unpack(payloadData)
 		if err != nil {
+			// unpack can fail for payloads like "{}", in this case we just forward the packet
 			ctx.Logger().Debug(fmt.Sprintf("failed to unpack: %s", err.Error()))
 			return im.app.OnRecvPacket(ctx, modulePacket, relayer)
 		}

--- a/x/gmp/module_ibc_test.go
+++ b/x/gmp/module_ibc_test.go
@@ -1,0 +1,257 @@
+package gmp_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"cosmossdk.io/log"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/address"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/sagaxyz/ssc/x/gmp"
+	"github.com/sagaxyz/ssc/x/gmp/types"
+	"github.com/stretchr/testify/require"
+
+	capabilitytypes "github.com/cosmos/ibc-go/modules/capability/types"
+	transfertypes "github.com/cosmos/ibc-go/v8/modules/apps/transfer/types"
+	channeltypes "github.com/cosmos/ibc-go/v8/modules/core/04-channel/types"
+	ibcexported "github.com/cosmos/ibc-go/v8/modules/core/exported"
+)
+
+type mockIBCModule struct {
+	lastPacket  channeltypes.Packet
+	lastRelayer sdk.AccAddress
+	lastCalled  string
+	returnAck   ibcexported.Acknowledgement
+}
+
+func (m *mockIBCModule) OnRecvPacket(
+	ctx sdk.Context,
+	packet channeltypes.Packet,
+	relayer sdk.AccAddress,
+) ibcexported.Acknowledgement {
+	m.lastPacket = packet
+	m.lastRelayer = relayer
+	m.lastCalled = "OnRecvPacket"
+	if m.returnAck != nil {
+		return m.returnAck
+	}
+	return channeltypes.NewResultAcknowledgement([]byte("mock"))
+}
+
+func (m *mockIBCModule) OnChanOpenInit(
+	ctx sdk.Context,
+	order channeltypes.Order,
+	connectionHops []string,
+	portID string,
+	channelID string,
+	chanCap *capabilitytypes.Capability,
+	counterparty channeltypes.Counterparty,
+	version string,
+) (string, error) {
+	return "", nil
+}
+
+func (m *mockIBCModule) OnChanOpenTry(
+	ctx sdk.Context,
+	order channeltypes.Order,
+	connectionHops []string,
+	portID string,
+	channelID string,
+	chanCap *capabilitytypes.Capability,
+	counterparty channeltypes.Counterparty,
+	counterpartyVersion string,
+) (string, error) {
+	return "", nil
+}
+
+func (m *mockIBCModule) OnChanOpenAck(
+	ctx sdk.Context,
+	portID,
+	channelID,
+	counterpartyChannelID,
+	counterpartyVersion string,
+) error {
+	return nil
+}
+
+func (m *mockIBCModule) OnChanOpenConfirm(
+	ctx sdk.Context,
+	portID,
+	channelID string,
+) error {
+	return nil
+}
+
+func (m *mockIBCModule) OnChanCloseInit(
+	ctx sdk.Context,
+	portID,
+	channelID string,
+) error {
+	return nil
+}
+
+func (m *mockIBCModule) OnChanCloseConfirm(
+	ctx sdk.Context,
+	portID,
+	channelID string,
+) error {
+	return nil
+}
+
+func (m *mockIBCModule) OnAcknowledgementPacket(
+	ctx sdk.Context,
+	packet channeltypes.Packet,
+	acknowledgement []byte,
+	relayer sdk.AccAddress,
+) error {
+	return nil
+}
+
+func (m *mockIBCModule) OnTimeoutPacket(
+	ctx sdk.Context,
+	packet channeltypes.Packet,
+	relayer sdk.AccAddress,
+) error {
+	return nil
+}
+
+func makePacketWithMemo(t *testing.T, memo string) channeltypes.Packet {
+	data := transfertypes.FungibleTokenPacketData{
+		Denom:    "foo",
+		Amount:   "1",
+		Sender:   "sender",
+		Receiver: "receiver",
+		Memo:     memo,
+	}
+	bz, err := types.ModuleCdc.MarshalJSON(&data)
+	require.NoError(t, err)
+	return channeltypes.Packet{
+		Data: bz,
+	}
+}
+
+func TestOnRecvPacket(t *testing.T) {
+	relayer := sdk.AccAddress(address.Module("relayer"))
+	ctx := sdk.Context{}.WithLogger(log.NewNopLogger())
+
+	t.Run("invalid packet data", func(t *testing.T) {
+		mock := &mockIBCModule{}
+		mod := gmp.NewIBCModule(mock)
+		// invalid JSON
+		packet := channeltypes.Packet{Data: []byte("{invalid-json")}
+		ack := mod.OnRecvPacket(ctx, packet, relayer)
+		require.Equal(t, "OnRecvPacket", mock.lastCalled)
+		require.NotNil(t, ack)
+	})
+
+	t.Run("invalid memo", func(t *testing.T) {
+		mock := &mockIBCModule{}
+		mod := gmp.NewIBCModule(mock)
+		// valid packet, invalid memo
+		data := transfertypes.FungibleTokenPacketData{
+			Denom:    "foo",
+			Amount:   "1",
+			Sender:   "sender",
+			Receiver: "receiver",
+			Memo:     "{invalid-json",
+		}
+		bz, err := types.ModuleCdc.MarshalJSON(&data)
+		require.NoError(t, err)
+		packet := channeltypes.Packet{Data: bz}
+		ack := mod.OnRecvPacket(ctx, packet, relayer)
+		require.Equal(t, "OnRecvPacket", mock.lastCalled)
+		require.NotNil(t, ack)
+	})
+
+	t.Run("empty payload", func(t *testing.T) {
+		mock := &mockIBCModule{}
+		mod := gmp.NewIBCModule(mock)
+		msg := gmp.Message{
+			SourceChain:   "chainA",
+			SourceAddress: "addr",
+			Payload:       []byte{},
+			Type:          gmp.TypeGeneralMessage,
+		}
+		memo, err := json.Marshal(msg)
+		require.NoError(t, err)
+		packet := makePacketWithMemo(t, string(memo))
+		ack := mod.OnRecvPacket(ctx, packet, relayer)
+		require.Equal(t, "OnRecvPacket", mock.lastCalled)
+		require.NotNil(t, ack)
+	})
+
+	t.Run("TypeGeneralMessage", func(t *testing.T) {
+		mock := &mockIBCModule{}
+		mod := gmp.NewIBCModule(mock)
+		msg := gmp.Message{
+			SourceChain:   "chainA",
+			SourceAddress: "addr",
+			Payload:       []byte("payload"),
+			Type:          gmp.TypeGeneralMessage,
+		}
+		memo, err := json.Marshal(msg)
+		require.NoError(t, err)
+		packet := makePacketWithMemo(t, string(memo))
+		ack := mod.OnRecvPacket(ctx, packet, relayer)
+		require.Equal(t, "OnRecvPacket", mock.lastCalled)
+		require.NotNil(t, ack)
+	})
+
+	t.Run("TypeGeneralMessageWithToken valid ABI", func(t *testing.T) {
+		mock := &mockIBCModule{}
+		mod := gmp.NewIBCModule(mock)
+		payloadType, err := abi.NewType("string", "", nil)
+		require.NoError(t, err)
+		args := abi.Arguments{{Type: payloadType}}
+		encoded, err := args.Pack("pfm-memo")
+		require.NoError(t, err)
+		msg := gmp.Message{
+			SourceChain:   "chainA",
+			SourceAddress: "addr",
+			Payload:       encoded,
+			Type:          gmp.TypeGeneralMessageWithToken,
+		}
+		memo, err := json.Marshal(msg)
+		require.NoError(t, err)
+		packet := makePacketWithMemo(t, string(memo))
+		ack := mod.OnRecvPacket(ctx, packet, relayer)
+		require.Equal(t, "OnRecvPacket", mock.lastCalled)
+		require.NotNil(t, ack)
+	})
+
+	t.Run("TypeGeneralMessageWithToken invalid ABI", func(t *testing.T) {
+		mock := &mockIBCModule{}
+		mod := gmp.NewIBCModule(mock)
+		msg := gmp.Message{
+			SourceChain:   "chainA",
+			SourceAddress: "addr",
+			Payload:       []byte("{}"), // not valid ABI encoding
+			Type:          gmp.TypeGeneralMessageWithToken,
+		}
+		memo, err := json.Marshal(msg)
+		require.NoError(t, err)
+		packet := makePacketWithMemo(t, string(memo))
+		ack := mod.OnRecvPacket(ctx, packet, relayer)
+		require.Equal(t, "OnRecvPacket", mock.lastCalled)
+		require.NotNil(t, ack)
+	})
+
+	t.Run("unrecognized type", func(t *testing.T) {
+		mock := &mockIBCModule{}
+		mod := gmp.NewIBCModule(mock)
+		msg := gmp.Message{
+			SourceChain:   "chainA",
+			SourceAddress: "addr",
+			Payload:       []byte("payload"),
+			Type:          int64(999),
+		}
+		memo, err := json.Marshal(msg)
+		require.NoError(t, err)
+		packet := makePacketWithMemo(t, string(memo))
+		ack := mod.OnRecvPacket(ctx, packet, relayer)
+		require.NotNil(t, ack)
+		// Should not call underlying OnRecvPacket for unrecognized type
+		require.NotEqual(t, "OnRecvPacket", mock.lastCalled)
+	})
+}

--- a/x/gmp/module_simulation.go
+++ b/x/gmp/module_simulation.go
@@ -43,7 +43,7 @@ func (AppModule) GenerateGenesisState(simState *module.SimulationState) {
 // func (am AppModule) RegisterStoreDecoder(_ sdk.StoreDecoderRegistry) {}
 
 // ProposalContents doesn't return any content functions for governance proposals.
-func (AppModule) ProposalContents(_ module.SimulationState) []simtypes.WeightedProposalContent {
+func (AppModule) ProposalContents(_ module.SimulationState) []simtypes.WeightedProposalMsg {
 	return nil
 }
 

--- a/x/ssc/client/cli/tx.go
+++ b/x/ssc/client/cli/tx.go
@@ -14,11 +14,6 @@ var (
 	DefaultRelativePacketTimeoutTimestamp = (time.Duration(10) * time.Minute).Nanoseconds()
 )
 
-const (
-	flagPacketTimeoutTimestamp = "packet-timeout-timestamp"
-	listSeparator              = ","
-)
-
 // GetTxCmd returns the transaction commands for this module
 func GetTxCmd() *cobra.Command {
 	cmd := &cobra.Command{

--- a/x/ssc/keeper/msg_server_test.go
+++ b/x/ssc/keeper/msg_server_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	keepertest "github.com/sagaxyz/ssc/testutil/keeper"
 	"github.com/sagaxyz/ssc/x/ssc/keeper"
 	"github.com/sagaxyz/ssc/x/ssc/types"
@@ -13,7 +12,7 @@ import (
 
 func setupMsgServer(t testing.TB) (types.MsgServer, context.Context) {
 	k, ctx := keepertest.SscKeeper(t)
-	return keeper.NewMsgServerImpl(*k), sdk.WrapSDKContext(ctx)
+	return keeper.NewMsgServerImpl(*k), ctx
 }
 
 func TestMsgServer(t *testing.T) {

--- a/x/ssc/keeper/query_params_test.go
+++ b/x/ssc/keeper/query_params_test.go
@@ -3,7 +3,6 @@ package keeper_test
 import (
 	"testing"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	testkeeper "github.com/sagaxyz/ssc/testutil/keeper"
 	"github.com/sagaxyz/ssc/x/ssc/types"
 	"github.com/stretchr/testify/require"
@@ -11,11 +10,10 @@ import (
 
 func TestParamsQuery(t *testing.T) {
 	keeper, ctx := testkeeper.SscKeeper(t)
-	wctx := sdk.WrapSDKContext(ctx)
 	params := types.DefaultParams()
 	keeper.SetParams(ctx, params)
 
-	response, err := keeper.Params(wctx, &types.QueryParamsRequest{})
+	response, err := keeper.Params(ctx, &types.QueryParamsRequest{})
 	require.NoError(t, err)
 	require.Equal(t, &types.QueryParamsResponse{Params: params}, response)
 }

--- a/x/ssc/module.go
+++ b/x/ssc/module.go
@@ -71,7 +71,7 @@ func (AppModuleBasic) ValidateGenesis(cdc codec.JSONCodec, config client.TxEncod
 
 // RegisterGRPCGatewayRoutes registers the gRPC Gateway routes for the module
 func (AppModuleBasic) RegisterGRPCGatewayRoutes(clientCtx client.Context, mux *runtime.ServeMux) {
-	types.RegisterQueryHandlerClient(context.Background(), mux, types.NewQueryClient(clientCtx))
+	types.RegisterQueryHandlerClient(context.Background(), mux, types.NewQueryClient(clientCtx)) //nolint:errcheck
 }
 
 // GetTxCmd returns the root Tx command for the module. The subcommands of this root command are used by end-users to generate new transactions containing messages defined in the module

--- a/x/ssc/module_simulation.go
+++ b/x/ssc/module_simulation.go
@@ -42,7 +42,7 @@ func (AppModule) GenerateGenesisState(simState *module.SimulationState) {
 // func (am AppModule) RegisterStoreDecoder(_ sdk.StoreDecoderRegistry) {}
 
 // ProposalContents doesn't return any content functions for governance proposals.
-func (AppModule) ProposalContents(_ module.SimulationState) []simtypes.WeightedProposalContent {
+func (AppModule) ProposalContents(_ module.SimulationState) []simtypes.WeightedProposalMsg {
 	return nil
 }
 


### PR DESCRIPTION
Forward GMP message further instead of returning acknowledgment error when message got a non EVM ABI decodable payload.

PR also introduce 0.2->0.3 upgrade handler, as well as unit tests for GMP module and some cosmetic fixes.

Motivation: PR aims to prevent situations when it's possible to send funds to SSC and set payload to `{}` or something like that. That will make SSC compatible with other Cosmos chains as well as with SSC before the GMP handler was introduced.