### PR TITLE
Update hooks.go for delete double event emit

### DIFF
--- a/x/epochs/types/hooks.go
+++ b/x/epochs/types/hooks.go
@@ -74,7 +74,6 @@ func applyFuncIfNoError(ctx sdk.Context, f func(ctx sdk.Context) error) (err err
 	} else {
 		// no error, write the output of f
 		write()
-		ctx.EventManager().EmitEvents(cacheCtx.EventManager().Events())
 	}
 	return err
 }


### PR DESCRIPTION
This PR is target to resolve [issue-38](https://github.com/sagaxyz/ssc/issues/38).


## Introduction
In the following code, your Project emit cachecontext twice which is not necessary and allowing emit same event twice.
```golang

// CacheContext returns a new Context with the multi-store cached and a new
// EventManager. The cached context is written to the context when writeCache
// is called. Note, events are automatically emitted on the parent context's
// EventManager when the caller executes the write.
func (c Context) CacheContext() (cc Context, writeCache func()) {
	cms := c.ms.CacheMultiStore()
	cc = c.WithMultiStore(cms).WithEventManager(NewEventManager())

	writeCache = func() {
		c.EventManager().EmitEvents(cc.EventManager().Events())
		cms.Write()
	}

	return cc, writeCache
}
```
https://github.com/sagaxyz/ssc/blob/e4d2dd7edc19ac8596d1915989ab881486a870dd/x/epochs/types/hooks.go#L61-L80