### PR TITLE
Adding 0.4 to 0.5 upgrade handler to release/0.5 branch

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -140,6 +140,7 @@ import (
 	upgrade02 "github.com/sagaxyz/ssc/app/upgrades/0.2"
 	upgrade03 "github.com/sagaxyz/ssc/app/upgrades/0.3"
 	upgrade04 "github.com/sagaxyz/ssc/app/upgrades/0.4"
+	upgrade05 "github.com/sagaxyz/ssc/app/upgrades/0.5"
 
 	// this line is used by starport scaffolding # stargate/app/moduleImport
 
@@ -1107,6 +1108,7 @@ func (app *App) RegisterUpgradeHandlers() {
 	app.UpgradeKeeper.SetUpgradeHandler(upgrade02.Name, upgrade02.UpgradeHandler(app.mm, app.configurator, app.ParamsKeeper, &app.ConsensusParamsKeeper, app.IBCKeeper.ClientKeeper, baseAppLegacySS))
 	app.UpgradeKeeper.SetUpgradeHandler(upgrade03.Name, upgrade03.UpgradeHandler(app.mm, app.configurator))
 	app.UpgradeKeeper.SetUpgradeHandler(upgrade04.Name, upgrade04.UpgradeHandler(app.mm, app.configurator))
+	app.UpgradeKeeper.SetUpgradeHandler(upgrade05.Name, upgrade05.UpgradeHandler(app.mm, app.configurator))
 
 	upgradeInfo, err := app.UpgradeKeeper.ReadUpgradeInfoFromDisk()
 	if err != nil {

--- a/app/upgrades/0.5/upgrades.go
+++ b/app/upgrades/0.5/upgrades.go
@@ -1,0 +1,16 @@
+package v05
+
+import (
+	"context"
+
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+)
+
+const Name = "0.4-to-0.5"
+
+func UpgradeHandler(mm *module.Manager, configurator module.Configurator) upgradetypes.UpgradeHandler {
+	return func(ctx context.Context, _ upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
+		return mm.RunMigrations(ctx, configurator, vm)
+	}
+}


### PR DESCRIPTION
**Objective**: PR is to add an upgrade handler from 0.4 to 0.5 of SSC.

**Actions:**
Built the incoming branch off of `release/0.5`, added the upgrade handler, and then built image `sagaxyz/ssc:0.5.0-alpha.1` and tested it successfully in `staging`.

All 10 validators came up and we have block production in `staging` after chain halt, and the subsequent upgrade.