### PR TITLE
Set chainlet module authority

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -168,6 +168,7 @@ import (
 const (
 	AccountAddressPrefix = "saga"
 	Name                 = "ssc"
+	SagaAddress          = "saga1h8r6gm4jehflfn2nn7mtw53l37skrke5kyax8l"
 )
 
 // this line is used by starport scaffolding # stargate/wasm/app/enabledProposals
@@ -743,6 +744,7 @@ func New(
 		appCodec,
 		keys[chainletmoduletypes.StoreKey],
 		app.GetSubspace(chainletmoduletypes.ModuleName),
+		SagaAddress,
 		app.StakingKeeper,
 		icaControllerKeeper,
 		app.MsgServiceRouter(),

--- a/x/chainlet/keeper/keeper.go
+++ b/x/chainlet/keeper/keeper.go
@@ -30,12 +30,14 @@ type Keeper struct {
 	aclKeeper        types.AclKeeper
 
 	stackVersions map[string]*versions.Versions // display name => version tree
+	authority     string
 }
 
 func NewKeeper(
 	cdc codec.Codec,
 	storeKey storetypes.StoreKey,
 	ps paramtypes.Subspace,
+	authority string,
 	stakingKeeper types.StakingKeeper,
 	icaKeeper types.ICAKeeper,
 	msgRouter icatypes.MessageRouter,
@@ -56,6 +58,7 @@ func NewKeeper(
 		cdc:              cdc,
 		storeKey:         storeKey,
 		paramstore:       ps,
+		authority:        authority,
 		stakingKeeper:    stakingKeeper,
 		icaKeeper:        icaKeeper,
 		msgRouter:        msgRouter,
@@ -75,4 +78,8 @@ func (k *Keeper) Logger(ctx sdk.Context) log.Logger {
 
 func (k *Keeper) StackVersions(stackName string) *versions.Versions {
 	return k.stackVersions[stackName]
+}
+
+func (k *Keeper) GetAuthority() string {
+	return k.authority
 }


### PR DESCRIPTION
Sets the chainlet module authority to the SagaAddress. This is necessary to perform gated actions during the migration.