### PR TITLE
fix: Gas difference when loading versions cache

### DIFF
--- a/x/chainlet/keeper/versions.go
+++ b/x/chainlet/keeper/versions.go
@@ -4,11 +4,18 @@ import (
 	"cosmossdk.io/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	storetypes "cosmossdk.io/store/types"
 	"github.com/sagaxyz/ssc/x/chainlet/types"
 	"github.com/sagaxyz/ssc/x/chainlet/types/versions"
 )
 
-func (k *Keeper) loadVersions(ctx sdk.Context) error {
+func (k *Keeper) loadVersions(c sdk.Context) error {
+	// Create a new context with an infinite gas meter, to avoid consuming gas.
+	// This is in order to avoid any difference in gas consumption between nodes
+	// that load the versions cache.
+	ctx, _ := c.CacheContext()
+	ctx = ctx.WithGasMeter(storetypes.NewInfiniteGasMeter())
+
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.ChainletStackKey)
 
 	it := store.Iterator(nil, nil)

--- a/x/chainlet/keeper/versions_test.go
+++ b/x/chainlet/keeper/versions_test.go
@@ -82,9 +82,11 @@ func (s *TestSuite) TestVersionsLoading() {
 		s.Require().Equal(tt.expectedState, versions)
 
 		s.chainletKeeper.DeleteVersions()
-		// Force re-load
+		// Force re-load, making sure no gas is consumed
+		gas := s.ctx.GasMeter().GasConsumed() // get the gas amount before the function call
 		_, err = s.chainletKeeper.LatestVersion(s.ctx, "test", "1.2.3")
 		s.Require().NoError(err)
+		s.Require().Equal(gas, s.ctx.GasMeter().GasConsumed()) // this function must not consume gas
 		versions = s.chainletKeeper.Versions("test")
 		s.Require().Equal(tt.expectedState, versions)
 	}


### PR DESCRIPTION
This fix allows nodes to load their in-mem caches independently, without consuming any gas and modifying the block result.